### PR TITLE
feat: Add diagnostic logging for static asset serving

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -52,6 +52,13 @@ export default {
         // Fallback if ASSETS.fetch is not available (e.g., misconfiguration)
         // This could be a 404 or a specific error message.
         // For now, let's return a clear message indicating the issue.
+        console.log('env keys:', Object.keys(env));
+        if (env.ASSETS) {
+          console.log('typeof env.ASSETS:', typeof env.ASSETS);
+          if (typeof env.ASSETS === 'object') {
+            console.log('env.ASSETS keys:', Object.keys(env.ASSETS));
+          }
+        }
         console.warn('env.ASSETS.fetch is not available. Ensure [site] is configured in wrangler.toml for static assets.');
         return new Response('Static asset serving is not configured.', { status: 404 });
       }


### PR DESCRIPTION
This commit adds more detailed logging to the Cloudflare entry point (`src/index.js`). When I determine that static asset serving via `env.ASSETS.fetch` is not available, I will now log:
- The keys present in the `env` object.
- The type of `env.ASSETS` (if it exists).
- The keys of `env.ASSETS` (if it is an object).

This additional information should help diagnose why static assets might not be served correctly when deployed to Cloudflare Pages, particularly if the `env.ASSETS` binding is missing or not what's expected.

If these logs show that `env.ASSETS` is indeed unavailable or not correctly populated, the issue may be related to your Cloudflare Pages project configuration, the deployment environment, or a platform-level interaction, and may require further investigation beyond the codebase itself.