### PR TITLE
fix: Use __STATIC_CONTENT for static asset serving

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -39,20 +39,27 @@ export default {
       }
     } else {
       // If no pattern matches, delegate to static asset serving
-      // Ensure env.ASSETS is available and is a fetch handler
-      if (env.ASSETS && typeof env.ASSETS.fetch === 'function') {
+      // Ensure env.__STATIC_CONTENT is available and is a fetch handler
+      if (env.__STATIC_CONTENT && typeof env.__STATIC_CONTENT.fetch === 'function') {
         try {
-          return await env.ASSETS.fetch(request);
+          return await env.__STATIC_CONTENT.fetch(request);
         } catch (error) {
-          console.error('Error fetching from ASSETS:', error);
-          // If ASSETS.fetch fails, return a generic error or a specific message
+          console.error('Error fetching from __STATIC_CONTENT:', error);
+          // If __STATIC_CONTENT.fetch fails, return a generic error or a specific message
           return new Response('Error serving static asset', { status: 500 });
         }
       } else {
-        // Fallback if ASSETS.fetch is not available (e.g., misconfiguration)
+        // Fallback if __STATIC_CONTENT.fetch is not available (e.g., misconfiguration)
         // This could be a 404 or a specific error message.
         // For now, let's return a clear message indicating the issue.
-        console.warn('env.ASSETS.fetch is not available. Ensure [site] is configured in wrangler.toml for static assets.');
+        console.log('env keys:', Object.keys(env));
+        if (env.__STATIC_CONTENT) {
+          console.log('typeof env.__STATIC_CONTENT:', typeof env.__STATIC_CONTENT);
+          if (typeof env.__STATIC_CONTENT === 'object') {
+            console.log('env.__STATIC_CONTENT keys:', Object.keys(env.__STATIC_CONTENT));
+          }
+        }
+        console.warn('env.__STATIC_CONTENT.fetch is not available. Ensure [site] is configured in wrangler.toml and the binding is correctly named __STATIC_CONTENT.');
         return new Response('Static asset serving is not configured.', { status: 404 });
       }
     }


### PR DESCRIPTION
I've updated the Cloudflare script (`src/index.js`) to use `env.__STATIC_CONTENT.fetch` for serving static assets.

Diagnostic logs revealed that the static asset binding in the deployment environment is named `__STATIC_CONTENT`, not the more commonly documented `ASSETS`. This change aligns the script with the actual environment binding.

This should resolve the "Static asset serving is not configured" error and allow static files to be served correctly.